### PR TITLE
Remove call to queue message and instead hide buttons window outside of PvP contexts

### DIFF
--- a/IncCallout.lua
+++ b/IncCallout.lua
@@ -364,11 +364,11 @@ f:SetScript("OnEvent", function(self, event, ...)
         if location then
             IncCallout:Show()  -- Show the GUI
         else
-            
+            IncCallout:Hide()  -- Hide the GUI
         end
     end
 end)
- 
+
 -- Now that IncCallout is defined, you can create IncCalloutLDB
 local IncCalloutLDB = LibStub("LibDataBroker-1.1"):NewDataObject("IncCallout", {
     type = "data source",
@@ -465,11 +465,11 @@ local function OnEvent(self, event, ...)
         if inInstance and (instanceType == "pvp" or instanceType == "arena") then
     
         else
-            print("|cFFFF0000You need to queue up for PvP|r")
+            IncCallout:Hide() 
         end
         
         if inInstance and instanceType == "pvp" then
-            IncCalloutMainFrame:Show() 
+            IncCallout:Show() 
         end
  
     elseif event == "PLAYER_LOGIN" then
@@ -551,15 +551,3 @@ IncCallout:RegisterEvent("PLAYER_ENTERING_WORLD")
 IncCallout:RegisterEvent("PLAYER_LOGIN")
 IncCallout:RegisterEvent("PLAYER_LOGOUT")
 IncCallout:SetScript("OnEvent", OnEvent)
-
-
-
-
-
-
-
-
-
-
-
-

--- a/IncCallout.lua
+++ b/IncCallout.lua
@@ -364,7 +364,7 @@ f:SetScript("OnEvent", function(self, event, ...)
         if location then
             IncCallout:Show()  -- Show the GUI
         else
-            IncCallout:Hide()  -- Hide the GUI
+            
         end
     end
 end)


### PR DESCRIPTION
After every load screen there is a message to queue up for PvP. This commit removes the message.
Also after every load screen, the buttons window is shown anywhere in-game, even in PvE content. This commit hides the buttons window outside of PvP content after a load screen.